### PR TITLE
Add content page, nav bar, and RSS feed

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "middleman",
+      "runtimeExecutable": ".claude/start-preview.sh",
+      "port": 4567
+    }
+  ]
+}

--- a/.claude/start-preview.sh
+++ b/.claude/start-preview.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+PORT="${PORT:-4567}"
+exec devenv shell -- bundle exec middleman server --port "$PORT"

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 ruby '3.2.3'
 
 gem 'middleman', github: 'middleman/middleman', branch: 'main'
+gem 'middleman-blog'
 gem "kamal", '>= 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     memoist (0.16.2)
+    middleman-blog (4.2.1)
+      addressable (~> 2.3)
+      middleman-core (>= 4.0.0)
+      tzinfo (>= 0.3.0)
     minitest (5.25.5)
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
@@ -151,6 +155,7 @@ PLATFORMS
 DEPENDENCIES
   kamal (>= 2)
   middleman!
+  middleman-blog
 
 RUBY VERSION
    ruby 3.2.3p157

--- a/config.rb
+++ b/config.rb
@@ -7,7 +7,15 @@ page '/*.json', layout: false
 page '/*.txt', layout: false
 
 ignore '**/.keep'
-activate :asset_hash
+activate :asset_hash, ignore: ["feed.xml"]
+
+activate :blog do |blog|
+  blog.prefix = "articles"
+  blog.permalink = "{title}.html"
+  blog.sources = "{title}.html"
+  blog.layout = "article"
+  blog.default_extension = ".md"
+end
 
 # With alternative layout
 # page '/path/to/file.html', layout: 'other_layout'

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -4,5 +4,6 @@
   <label for="hamburger" class="main-nav__mobile-menu-btn"><span class="main-nav__mobile-menu-btn-text">Menu</span><span class="main-nav__hamburger-menu"></span></label>
   <ul class="main-nav__list">
     <li class="main-nav__list-item"><%= link_to "Home", "/" %></li>
+    <li class="main-nav__list-item"><%= link_to "Content", "/content.html" %></li>
   </ul>
 </nav>

--- a/source/articles/14-tools-and-gems-every-ruby-developer-would-love.html.md
+++ b/source/articles/14-tools-and-gems-every-ruby-developer-would-love.html.md
@@ -1,0 +1,8 @@
+---
+title: 14 tools every Ruby developer will love for performance and debugging
+date: 2024-03-25
+kind: post
+source: Test Double Blog
+external_url: https://testdouble.com/insights/14-tools-and-gems-every-ruby-developer-would-love
+description: A curated list of fourteen Ruby gems and tools organized by feedback loops, performance debugging, and data management.
+---

--- a/source/articles/azure-blob-a-new-ruby-gem-for-azure-blob-storage.html.md
+++ b/source/articles/azure-blob-a-new-ruby-gem-for-azure-blob-storage.html.md
@@ -1,0 +1,8 @@
+---
+title: "Introducing azure-blob: A new Ruby gem for Azure Blob Storage"
+date: 2024-09-11
+kind: post
+source: Test Double Blog
+external_url: https://testdouble.com/insights/azure-blob-a-new-ruby-gem-for-azure-blob-storage
+description: A replacement for the deprecated azure-storage-blob gem, featuring Managed Identities support and zero external dependencies.
+---

--- a/source/articles/get-in-the-box-illustrated-permissions-guide-to-make-claude-chill.html.md
+++ b/source/articles/get-in-the-box-illustrated-permissions-guide-to-make-claude-chill.html.md
@@ -1,0 +1,8 @@
+---
+title: "Get in the box: Illustrated permissions guide to make Claude chill"
+date: 2026-04-07
+kind: post
+source: Test Double Blog
+external_url: https://testdouble.com/insights/get-in-the-box-illustrated-permissions-guide-to-make-claude-chill
+description: A practical guide to configuring Claude Code's sandbox environment to minimize permission prompts while maintaining security.
+---

--- a/source/articles/thruster-vs-kamal-proxy-guide.html.md
+++ b/source/articles/thruster-vs-kamal-proxy-guide.html.md
@@ -1,0 +1,8 @@
+---
+title: "Thruster vs Kamal-proxy: Which HTTP proxy is right for you?"
+date: 2025-03-25
+kind: post
+source: Test Double Blog
+external_url: https://testdouble.com/insights/thruster-vs-kamal-proxy-guide
+description: A comparison of two 37signals HTTP proxies -- Thruster for single-app rapid deployment and Kamal-proxy for multi-app zero-downtime deployments.
+---

--- a/source/content.html.erb
+++ b/source/content.html.erb
@@ -1,0 +1,22 @@
+---
+title: Content
+---
+
+<div class="content-page">
+  <h1 class="content-page__title">Content</h1>
+
+  <div class="content-page__list">
+    <% blog.articles.each do |article| %>
+      <% url = article.data.external_url || article.url %>
+      <% external = article.data.external_url.present? %>
+      <a href="<%= url %>" class="content-page__item" <% if external %>target="_blank" rel="noopener"<% end %>>
+        <div class="content-page__item-meta">
+          <span class="content-page__badge content-page__badge--<%= article.data.kind %>"><%= article.data.kind.upcase %></span>
+          <span class="content-page__source"><%= article.data.source %> &middot; <%= article.date.strftime("%b %Y") %></span>
+        </div>
+        <h2 class="content-page__item-title"><%= article.title %></h2>
+        <p class="content-page__item-description"><%= article.data.description %></p>
+      </a>
+    <% end %>
+  </div>
+</div>

--- a/source/feed.xml.erb
+++ b/source/feed.xml.erb
@@ -1,0 +1,32 @@
+---
+layout: false
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Joe Dupuis</title>
+  <id>https://joe.dupuis.io</id>
+  <link href="https://joe.dupuis.io/feed.xml" rel="self"/>
+  <link href="https://joe.dupuis.io"/>
+  <% unless blog.articles.empty? %>
+  <updated><%= blog.articles.first.date.to_time.iso8601 %></updated>
+  <% end %>
+  <author><name>Joe Dupuis</name></author>
+  <% blog.articles.each do |article| %>
+  <% article_url = article.data.external_url || "https://joe.dupuis.io#{article.url}" %>
+  <entry>
+    <title><%= article.title %></title>
+    <link href="<%= article_url %>" rel="alternate"/>
+    <id><%= article_url %></id>
+    <published><%= article.date.to_time.iso8601 %></published>
+    <updated><%= article.date.to_time.iso8601 %></updated>
+    <% if article.data.description %>
+    <summary><%= article.data.description %></summary>
+    <% end %>
+    <% if article.data.external_url %>
+    <content type="html">&lt;p&gt;<%= article.data.description %>&lt;/p&gt;&lt;p&gt;&lt;a href="<%= article.data.external_url %>"&gt;Read on <%= article.data.source %>&lt;/a&gt;&lt;/p&gt;</content>
+    <% elsif article.body.present? %>
+    <content type="html"><%= ERB::Util.html_escape(article.body) %></content>
+    <% end %>
+  </entry>
+  <% end %>
+</feed>

--- a/source/layouts/article.erb
+++ b/source/layouts/article.erb
@@ -1,0 +1,11 @@
+<% wrap_layout :layout do %>
+  <article class="article">
+    <h1 class="article__title"><%= current_article.title %></h1>
+    <div class="article__meta">
+      <time><%= current_article.date.strftime("%B %e, %Y") %></time>
+    </div>
+    <div class="article__body">
+      <%= yield %>
+    </div>
+  </article>
+<% end %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -10,7 +10,7 @@
     <%= stylesheet_link_all %>
   </head>
   <body>
-    <%# partial :nav %>
+    <%= partial :nav %>
     <section class="page">
       <%= yield %>
     </section>

--- a/source/stylesheets/content.css
+++ b/source/stylesheets/content.css
@@ -1,0 +1,68 @@
+.content-page {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 2em 1em;
+}
+
+.content-page__title {
+  font-family: var(--text-font-family);
+  font-size: 2em;
+  margin-bottom: 1.5em;
+}
+
+.content-page__item {
+  display: block;
+  padding: 1.5em 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  text-decoration: none;
+  color: inherit;
+}
+
+.content-page__item:first-child {
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.content-page__item:hover .content-page__item-title {
+  color: #555;
+}
+
+.content-page__item-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.3em;
+}
+
+.content-page__badge {
+  display: inline-block;
+  padding: 0.15em 0.5em;
+  font-family: var(--heading-font-family);
+  font-size: 0.7em;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  border-radius: 3px;
+  background-color: var(--main-color);
+  color: var(--background-color);
+}
+
+.content-page__source {
+  font-family: var(--heading-font-family);
+  font-size: 0.85em;
+  color: #888;
+}
+
+.content-page__item-title {
+  font-family: var(--text-font-family);
+  font-size: 1.2em;
+  font-weight: 400;
+  margin: 0.1em 0 0.3em;
+  transition: color 0.15s;
+}
+
+.content-page__item-description {
+  font-family: var(--heading-font-family);
+  font-size: 0.9em;
+  color: #888;
+  margin: 0;
+  line-height: 1.5;
+}

--- a/source/stylesheets/nav.css
+++ b/source/stylesheets/nav.css
@@ -1,128 +1,136 @@
+.main-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5em;
+}
+
 .main-nav__brand {
-  display: inline-block;
+  font-family: var(--text-font-family);
   font-size: 1em;
-  padding: var(--main-nav-spacing);
+  font-weight: 700;
+  margin: 0;
+  padding: 1em 0;
 }
 
 .main-nav__brand a {
   text-decoration: none;
+  color: var(--main-color);
 }
 
 .main-nav__list {
-  transition: max-height 0.2s;
-  max-height: 0em;
-  overflow: hidden;
+  display: flex;
+  gap: 2em;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .main-nav__list-item {
-  list-style: none;
-  padding: 0.4em;
-  text-align: center;
   margin: 0;
-}
-
-.main-nav__list-item:hover {
-  background-color: rgba(0, 0, 0, 0.01);
+  padding: 0;
 }
 
 .main-nav__list-item a {
   text-decoration: none;
+  color: var(--main-color);
+  font-family: var(--heading-font-family);
+  font-size: 0.95em;
 }
 
-.main-nav__hamburger-checkbox:checked ~ .main-nav__list {
-  max-height: 10em;
-}
-
-.main-nav__hamburger-checkbox:checked ~ .main-nav__mobile-menu-btn .main-nav__hamburger-menu {
-  background-color: transparent;
-}
-
-.main-nav__hamburger-checkbox:checked ~ .main-nav__mobile-menu-btn .main-nav__hamburger-menu:before {
-  margin-top: 0;
-  transform: rotate(45deg);
-  transition: margin var(--main-nav-btn-delay), transform var(--main-nav-btn-delay) var(--main-nav-btn-delay);
-}
-
-.main-nav__hamburger-checkbox:checked ~ .main-nav__mobile-menu-btn .main-nav__hamburger-menu:after {
-  margin-top: 0;
-  transform: rotate(-45deg);
-  transition: margin var(--main-nav-btn-delay), transform var(--main-nav-btn-delay) var(--main-nav-btn-delay);
-}
-
-.main-nav__mobile-menu-btn {
-  display: inline-flex;
-  align-items: center;
-  cursor: pointer;
-  float: right;
-  padding: var(--main-nav-spacing);
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.main-nav__mobile-menu-btn-text {
-  text-indent: var(--text-displacement);
-  display: inline-block;
-}
-
-.main-nav__hamburger-menu,
-.main-nav__hamburger-menu:before,
-.main-nav__hamburger-menu:after {
-  width: var(--hamburger-width);
-  height: var(--hamburger-height);
-  border-radius: 10px;
-}
-
-.main-nav__hamburger-menu:before,
-.main-nav__hamburger-menu:after {
-  content: "";
-  position: absolute;
-  transition: margin var(--main-nav-btn-delay) var(--main-nav-btn-delay), transform var(--main-nav-btn-delay) 0s;
-}
-
-.main-nav__mobile-menu-btn .main-nav__hamburger-menu {
-  background-color: var(--fg-color);
-  position: relative;
-  transition: background-color var(--main-nav-btn-delay);
-  width: var(--hamburger-width);
-  display: inline-flex;
-  justify-content: center;
-}
-
-.main-nav__mobile-menu-btn .main-nav__hamburger-menu:before {
-  background-color: var(--fg-color);
-  margin-top: calc(-1 * var(--hamburger-spread));
-  width: var(--hamburger-width);
-}
-
-.main-nav__mobile-menu-btn .main-nav__hamburger-menu:after {
-  background-color: var(--fg-color);
-  margin-top: var(--hamburger-spread);
-  width: var(--hamburger-width);
+.main-nav__list-item a:hover {
+  opacity: 0.6;
 }
 
 .main-nav__hamburger-checkbox {
   display: none;
 }
 
-@media screen and (min-width: 768px) {
+.main-nav__mobile-menu-btn {
+  display: none;
+}
+
+@media screen and (max-width: 767px) {
+  .main-nav {
+    flex-wrap: wrap;
+  }
+
   .main-nav__mobile-menu-btn {
-    display: none;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 1em 0;
+    -webkit-user-select: none;
+    user-select: none;
   }
-  
+
+  .main-nav__mobile-menu-btn-text {
+    text-indent: var(--text-displacement);
+    display: inline-block;
+  }
+
+  .main-nav__hamburger-menu,
+  .main-nav__hamburger-menu:before,
+  .main-nav__hamburger-menu:after {
+    width: var(--hamburger-width);
+    height: var(--hamburger-height);
+    border-radius: 10px;
+  }
+
+  .main-nav__hamburger-menu:before,
+  .main-nav__hamburger-menu:after {
+    content: "";
+    position: absolute;
+    transition: margin var(--main-nav-btn-delay) var(--main-nav-btn-delay), transform var(--main-nav-btn-delay) 0s;
+  }
+
+  .main-nav__mobile-menu-btn .main-nav__hamburger-menu {
+    background-color: var(--main-color);
+    position: relative;
+    transition: background-color var(--main-nav-btn-delay);
+    display: inline-flex;
+    justify-content: center;
+  }
+
+  .main-nav__mobile-menu-btn .main-nav__hamburger-menu:before {
+    background-color: var(--main-color);
+    margin-top: calc(-1 * var(--hamburger-spread));
+  }
+
+  .main-nav__mobile-menu-btn .main-nav__hamburger-menu:after {
+    background-color: var(--main-color);
+    margin-top: var(--hamburger-spread);
+  }
+
+  .main-nav__hamburger-checkbox:checked ~ .main-nav__mobile-menu-btn .main-nav__hamburger-menu {
+    background-color: transparent;
+  }
+
+  .main-nav__hamburger-checkbox:checked ~ .main-nav__mobile-menu-btn .main-nav__hamburger-menu:before {
+    margin-top: 0;
+    transform: rotate(45deg);
+    transition: margin var(--main-nav-btn-delay), transform var(--main-nav-btn-delay) var(--main-nav-btn-delay);
+  }
+
+  .main-nav__hamburger-checkbox:checked ~ .main-nav__mobile-menu-btn .main-nav__hamburger-menu:after {
+    margin-top: 0;
+    transform: rotate(-45deg);
+    transition: margin var(--main-nav-btn-delay), transform var(--main-nav-btn-delay) var(--main-nav-btn-delay);
+  }
+
   .main-nav__list {
-    display: inline-block;
-    height: auto;
-    max-height: none;
-    float: right;
-    margin: 0;
-    padding: 1em;
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    gap: 0;
+    text-align: center;
   }
-  
+
+  .main-nav__hamburger-checkbox:checked ~ .main-nav__list {
+    display: flex;
+  }
+
   .main-nav__list-item {
-    display: inline-block;
+    padding: 0.6em 0;
   }
 }


### PR DESCRIPTION
## Changes

- **Blog Integration**: Added `middleman-blog` gem for article management
- **Content Page**: Created `/content.html` displaying a curated list of articles with metadata
- **Navigation**: Enabled and updated navigation bar with "Content" link
- **RSS Feed**: Implemented Atom feed at `/feed.xml` for article syndication
- **Article Layout**: Added dedicated article layout template
- **Styling**: 
  - New `content.css` for content page styling
  - Refactored `nav.css` with improved mobile responsiveness and flexbox layout
- **Articles**: Added 4 sample articles from Test Double Blog with frontmatter metadata
- **Configuration**: Updated `config.rb` to configure blog settings and exclude feed.xml from asset hashing